### PR TITLE
Fix crash on logging non-system code page characters

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -27,7 +27,7 @@ import requests
 import subprocess
 import unicodedata
 from struct import unpack
-from sys import exit
+from sys import exit, stdout
 from typing import Optional
 
 from PIL import Image
@@ -45,6 +45,10 @@ class Generator():
         self.cmdarg = ""
         if os.name != "nt":
             self.cmdarg = "./"
+
+        # Running from the GUI on Windows defaults to the system code page
+        if stdout.encoding != "utf-8":
+            stdout.reconfigure(encoding="utf-8")
 
     title: dict = None
     gamecode: str = None


### PR DESCRIPTION
- I hate Windows
- Due to makerom not supporting Unicode on Windows, it will still crash if your file name has characters that aren't in your system code page