### PR TITLE
Check local files for custom boxart/sound.

### DIFF
--- a/generator/generator.py
+++ b/generator/generator.py
@@ -172,6 +172,21 @@ class Generator():
         self.gamecode = code
         return 0
 
+    def checklocalassets(self):
+        if not self.boxart:
+            if os.path.isfile(f"assets/{self.gamecode}/{self.gamecode}.png"):
+                self.boxart = os.path.abspath(f"assets/{self.gamecode}/{self.gamecode}.png")
+                self.boxartcustom = True
+            elif os.path.isfile(f"assets/{self.gamecode[0:3]}/{self.gamecode[0:3]}.png"):
+                self.boxart = os.path.abspath(f"assets/{self.gamecode[0:3]}/{self.gamecode[0:3]}.png")
+                self.boxartcustom = True
+        if  not self.sound:
+            if os.path.isfile(f"assets/{self.gamecode}/{self.gamecode}.wav"):
+                self.sound = os.path.abspath(f"assets/{self.gamecode}/{self.gamecode}.wav")
+            elif os.path.isfile(f"assets/{self.gamecode[0:3]}/{self.gamecode[0:3]}.wav"):
+                self.sound = os.path.abspath(f"assets/{self.gamecode[0:3]}/{self.gamecode[0:3]}.wav")
+        return 0
+
     def downloadfromgithub(self):
         if not self.boxart:
             r = requests.get(f"https://raw.githubusercontent.com/YANBForwarder/assets/main/assets/{self.gamecode}/{self.gamecode}.png", timeout=15)
@@ -237,7 +252,7 @@ class Generator():
         return 0
 
     def makebanner(self):
-        bannertoolarg = f'bannertool makebanner -i "data/banner.png" -a "{self.sound}" -o "data/banner.bin"'
+        bannertoolarg = f'bannertool makebanner -i "{self.boxart}" -a "{self.sound}" -o "data/banner.bin"'
         self.message(f"Using arguments: {bannertoolarg}")
         bannertoolrun = subprocess.run(f'{self.cmdarg}{bannertoolarg}', shell=True, capture_output=True, universal_newlines=True)
         if bannertoolrun.returncode != 0:
@@ -289,7 +304,7 @@ class Generator():
         return 0
 
     def makecia(self):
-        makeromarg = f'{self.cmdarg}makerom -f cia -target t -exefslogo -rsf data/build-cia.rsf -elf data/forwarder.elf -banner data/banner.bin -icon data/output.smdh -DAPP_ROMFS=romfs -major 1 -minor 6 -micro 3 -DAPP_VERSION_MAJOR=1 -o "{self.output}" '
+        makeromarg = f'{self.cmdarg}makerom -f cia -target t -exefslogo -rsf data/build-cia.rsf -elf data/forwarder.elf -banner data/banner.bin -icon data/output.smdh -DAPP_ROMFS=romfs -major 1 -minor 6 -micro 3 -DAPP_VERSION_MAJOR=1 -o "output/{self.output}" '
         makeromarg += f'-DAPP_PRODUCT_CODE=CTR-H-{self.gamecode} -DAPP_TITLE="{self.title["eng"][0]}" -DAPP_UNIQUE_ID={self.uniqueid}'
         self.message(f"Using arguments: {makeromarg}")
         makeromrun = subprocess.run(makeromarg, shell=True, capture_output=True, universal_newlines=True)
@@ -311,7 +326,7 @@ class Generator():
         if not self.output:
             self.output = f"{os.path.basename(self.infile)}.cia"
         self.message(f"Using ROM path: {self.path}")
-        self.message(f"Output file: {self.output}")
+        self.message(f"Output file: output/{self.output}")
         self.message("Getting gamecode...")
         self.getgamecode()
         self.message("Extracting and resizing icon...")
@@ -321,15 +336,18 @@ class Generator():
         self.message("Creating SMDH...")
         self.makesmdh()
         if not self.boxart or not self.sound:
-            self.message("Checking API if a custom banner or sound is provided...")
-            self.downloadfromgithub()
-            if not self.sound:
-                self.sound = os.path.abspath("data/dsboot.wav")
-            if not self.boxart:
-                self.message("No banner provided. Checking GameTDB for standard boxart...")
-                if self.downloadboxart() != 0:
-                    self.message("Banner was not found. Exiting.")
-                    exit()
+            self.message("Checking local files for a custom banner or sound...")
+            self.checklocalassets()
+            if not self.sound or not self.boxart:
+                self.message("Checking API if a custom banner or sound is provided...")
+                self.downloadfromgithub()
+                if not self.sound:
+                    self.sound = os.path.abspath("data/dsboot.wav")
+                if not self.boxart:
+                    self.message("No banner provided. Checking GameTDB for standard boxart...")
+                    if self.downloadboxart() != 0:
+                        self.message("Banner was not found. Exiting.")
+                        exit()
         self.message(f"Using sound file: {self.sound}")
         self.message(f"Using banner image: {self.boxart}")
         if not self.boxartcustom:

--- a/generator/generator.py
+++ b/generator/generator.py
@@ -304,7 +304,7 @@ class Generator():
         return 0
 
     def makecia(self):
-        makeromarg = f'{self.cmdarg}makerom -f cia -target t -exefslogo -rsf data/build-cia.rsf -elf data/forwarder.elf -banner data/banner.bin -icon data/output.smdh -DAPP_ROMFS=romfs -major 1 -minor 6 -micro 3 -DAPP_VERSION_MAJOR=1 -o "output/{self.output}" '
+        makeromarg = f'{self.cmdarg}makerom -f cia -target t -exefslogo -rsf data/build-cia.rsf -elf data/forwarder.elf -banner data/banner.bin -icon data/output.smdh -DAPP_ROMFS=romfs -major 1 -minor 6 -micro 3 -DAPP_VERSION_MAJOR=1 -o "{self.output}" '
         makeromarg += f'-DAPP_PRODUCT_CODE=CTR-H-{self.gamecode} -DAPP_TITLE="{self.title["eng"][0]}" -DAPP_UNIQUE_ID={self.uniqueid}'
         self.message(f"Using arguments: {makeromarg}")
         makeromrun = subprocess.run(makeromarg, shell=True, capture_output=True, universal_newlines=True)
@@ -326,7 +326,7 @@ class Generator():
         if not self.output:
             self.output = f"{os.path.basename(self.infile)}.cia"
         self.message(f"Using ROM path: {self.path}")
-        self.message(f"Output file: output/{self.output}")
+        self.message(f"Output file: {self.output}")
         self.message("Getting gamecode...")
         self.getgamecode()
         self.message("Extracting and resizing icon...")
@@ -385,6 +385,8 @@ if __name__ == "__main__":
         infile = args.input[0]
     if args.output:
         output = args.output[0]
+    else:
+        output = f"output/{os.path.basename(args.input[0])}.cia" #should be safe since infile is required
     if args.sound:
         sound = args.sound[0]
     if args.path:


### PR DESCRIPTION
Hi,
I have added in a few features for the generator.py. This is the first of a few smaller pull requests and adds the ability to use local files if they are available. This would streamline creating and testing new banners but may be less useful for the regular user as described in #27. There is currently no user prompt, since I would imagine that if a user actually uses local assets, they know what they are doing and don't want to be asked if they _really_ want to use local files.

The general way assets are chosen is the same as with the downloads from Github. Missing files still get downloaded.
The folder that gets checked is called "assets" and currently has to be in the same directory as the generator.exe file. I thought about having it a level up but since you only use the generator folder on windows and not bootstrap or forwarder, I feel like this is more straightforward.

There are also two small other changes in here:
1. Use the member var for the boxart instead of hardcoding "data/banner.png", this way local files don't need to be copied.
2. Change the output for the .cia files to the output folder, I always thought it was weird that they just get dropped next to the executable, which gets quite messy if you add a lot of roms.